### PR TITLE
Fix profile opening in header

### DIFF
--- a/web/dashboard.php
+++ b/web/dashboard.php
@@ -283,7 +283,7 @@ $token = $_GET['token'] ?? '';
             border-bottom: 1px solid rgba(0, 128, 255, 0.3);
             padding: 1.5rem 0;
             margin-bottom: 3rem;
-            overflow: hidden;
+            overflow: visible;
         }
 
         .header-bg-effect {


### PR DESCRIPTION
Fixes profile dropdown being cut off by the header by changing `overflow: hidden` to `overflow: visible` on `.main-header`.

---
<a href="https://cursor.com/background-agent?bcId=bc-23afdc28-1d08-4cbe-aab8-664e784eb752">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-23afdc28-1d08-4cbe-aab8-664e784eb752">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

